### PR TITLE
Includes react-native-vector-icons as dependency

### DIFF
--- a/packages/expo-web/package.json
+++ b/packages/expo-web/package.json
@@ -9,6 +9,7 @@
     "!**/__tests__"
   ],
   "dependencies": {
+    "react-native-vector-icons": "^4.5.0",
     "moment": "^2.20.1",
     "moment-timezone": "^0.5.14",
     "ua-parser-js": "^0.7.17"


### PR DESCRIPTION
In the same way that expo-sdk depends on @expo/vector-icons, this package depends on react-native-vector-icons.